### PR TITLE
Filter past shows and modularize data

### DIFF
--- a/src/data/upcomingShows.js
+++ b/src/data/upcomingShows.js
@@ -1,0 +1,38 @@
+export const shows = [
+  {
+    date: 'April 25, 2025',
+    venue: 'Summit Music Hall',
+    city: 'Columbus, OH',
+    title: 'Toadfest',
+    ticketLink:
+      'https://www.eventbrite.com/e/toadfest-2025-ft-cane-toads-koda-loconti-mamadog-many-more-tickets-1291966589849',
+  },
+  {
+    date: 'April 26, 2025',
+    venue: 'The Woods',
+    city: 'Oxford, OH',
+  },
+  {
+    date: 'May 3, 2025',
+    venue: 'Library Bar',
+    city: 'Columbus, OH',
+  },
+  {
+    date: 'August 22, 2025',
+    venue: 'Frostys',
+    city: 'Put-in-Bay, OH',
+    notes: 'Acoustic set, Time TBD',
+  },
+  {
+    date: 'August 23, 2025',
+    venue: 'Frostys',
+    city: 'Put-in-Bay, OH',
+    notes: 'Full band, Time TBD',
+  },
+  {
+    date: 'August 29, 2025',
+    venue: 'The Library Bar OSU',
+    city: 'Columbus, OH',
+    notes: '7:30-8:30 (Audley) / 9:00-11:00 (KODA)',
+  },
+]

--- a/src/pages/upcoming-shows.jsx
+++ b/src/pages/upcoming-shows.jsx
@@ -10,27 +10,12 @@ import {
 } from '@chakra-ui/react'
 import React from 'react'
 import { FaCalendarAlt, FaMapMarkerAlt } from 'react-icons/fa'
+import { shows as allShows } from '../data/upcomingShows'
 
-const shows = [
-  {
-    date: 'April 25, 2025',
-    venue: 'Summit Music Hall',
-    city: 'Columbus, OH',
-    title: 'Toadfest',
-    ticketLink:
-      'https://www.eventbrite.com/e/toadfest-2025-ft-cane-toads-koda-loconti-mamadog-many-more-tickets-1291966589849',
-  },
-  {
-    date: 'April 26, 2025',
-    venue: 'The Woods',
-    city: 'Oxford, OH',
-  },
-  {
-    date: 'May 3, 2025',
-    venue: 'Library Bar',
-    city: 'Columbus, OH',
-  },
-]
+const upcomingShows = allShows
+  .map((show) => ({ ...show, dateObj: new Date(show.date) }))
+  .filter((show) => show.dateObj >= new Date())
+  .sort((a, b) => a.dateObj - b.dateObj)
 
 const UpcomingShows = () => {
   return (
@@ -40,7 +25,7 @@ const UpcomingShows = () => {
       </Heading>
 
       <VStack spacing={6} maxW="800px" mx="auto">
-        {shows.map((show, idx) => (
+        {upcomingShows.map((show, idx) => (
           <Box
             key={idx}
             bg="gray.800"
@@ -69,6 +54,11 @@ const UpcomingShows = () => {
                     )}
                   </Text>
                 </Flex>
+                {show.notes && (
+                  <Text fontSize="sm" color="gray.400" mt={1}>
+                    {show.notes}
+                  </Text>
+                )}
               </Box>
 
               {/* Show status tags */}


### PR DESCRIPTION
## Summary
- store show information in `src/data/upcomingShows.js`
- filter out past shows and display note text in upcoming shows page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d48daf4148327939aa35062001438